### PR TITLE
Better way of detecting newly added apps

### DIFF
--- a/frontend/scripts/controllers/deploy_app_ctrl.js
+++ b/frontend/scripts/controllers/deploy_app_ctrl.js
@@ -4,6 +4,10 @@ angular.module("protonet.platform").controller("DeployAppCtrl", function($scope,
   $scope.docs = AppTutorial.get($scope.appType).deploy;
 
   function onAdd(event, app) {
+    // Ignore this until the initial set has been loaded
+    if (!App.loaded) {
+      return;
+    }
     App.off("add", onAdd);
     $scope.newApp = app;
   }


### PR DESCRIPTION
Refreshing the "deploy app page" (3rd step in the app wizard) caused that an already existing app was detected as being currently deployed which is wrong.
