### PR TITLE
add an option for a more detailed update status

### DIFF
--- a/frontend/scripts/controllers/install_update_ctrl.js
+++ b/frontend/scripts/controllers/install_update_ctrl.js
@@ -1,4 +1,25 @@
 angular.module("protonet.platform").controller("InstallUpdateCtrl", function($scope, $state, $timeout, API, Notification) {
+
+  function toggleDetailedUpdateStatus() {
+    $scope.showDetailedUpdateStatus = !$scope.showDetailedUpdateStatus;
+  }
+  $scope.toggleDetailedUpdateStatus = toggleDetailedUpdateStatus;
+
+  function updateDetailedStatus(images) {
+    $scope.status = {};
+    for (var property in images) {
+      if (images.hasOwnProperty(property)) {
+        var image = images[property];
+        $scope.status[property] = {
+          local: image.local,
+          remote: image.remote,
+          upToDate: image.local === image.remote
+        }
+      }
+    }
+    $scope.statusAvailable = !$.isEmptyObject($scope.status);
+  }
+
   function check() {
     $timeout(function() {
       API.get("/admin/api/system/update").then(function(data) {
@@ -6,6 +27,7 @@ angular.module("protonet.platform").controller("InstallUpdateCtrl", function($sc
           Notification.notice("Update successfully installed");
           $state.go("dashboard.index");
         } else {
+          updateDetailedStatus(data.images);
           check();
         }
       }).catch(check);

--- a/frontend/styles/application/pages/_install_update.scss
+++ b/frontend/styles/application/pages/_install_update.scss
@@ -13,4 +13,14 @@
     padding: 40px;
     text-align: center;
   }
+
+  .install-update-status-table {
+    margin-top: 30px;
+    tbody td {
+      padding: 10px;
+      &:first-child {
+        text-align: left;
+      }
+    }
+  }
 }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -43,14 +43,17 @@
 @font-face {
   font-family: "Protonet Text";
   src: url("../fonts/proxima_nova_cond_reg.woff") format("woff"); }
+
 @font-face {
   font-family: "Protonet Text";
   src: url("../fonts/proxima_nova_cond_light.woff") format("woff");
   font-weight: 100; }
+
 @font-face {
   font-family: "Protonet Text";
   src: url("../fonts/proxima_nova_cond_bold.woff") format("woff");
   font-weight: bold; }
+
 .code {
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace; }
 
@@ -74,7 +77,7 @@ body, textarea, select, input, button {
 
 h1 {
   font-size: 34px;
-  color: #4A4A4A;
+  color: #4a4a4a;
   font-weight: normal;
   margin: 0 0 20px; }
 
@@ -137,7 +140,7 @@ a {
   .wrapper {
     width: 550px; } }
 .material-box {
-  background-color: #ffffff;
+  background-color: white;
   box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
   display: inline-block;
   padding: 50px;
@@ -176,7 +179,7 @@ a {
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12); }
   .btn.cta {
     opacity: 1;
-    background: #FF9800; }
+    background: #ff9800; }
     .btn.cta:hover {
       background: #FFA72E; }
     .btn.cta:active {
@@ -318,7 +321,7 @@ input, textarea {
   color: #9E9E9E; }
   input:focus, textarea:focus {
     outline: none;
-    border-bottom: 1px solid #FF9800;
+    border-bottom: 1px solid #ff9800;
     color: #333; }
 
 input {
@@ -389,7 +392,7 @@ input[type=checkbox] {
       height: 17px;
       border: none;
       border-radius: 17px;
-      background: url("../images/done.svg") 40% 50% no-repeat #DDDDDD;
+      background: url("../images/done.svg") 40% 50% no-repeat #dddddd;
       background-size: 60%; }
     .step-bar li.active {
       background-color: #5892FC;
@@ -781,5 +784,9 @@ code {
     margin: 0 auto;
     padding: 40px;
     text-align: center; }
-
-/*# sourceMappingURL=main.css.map */
+  .install-update .install-update-status-table {
+    margin-top: 30px; }
+    .install-update .install-update-status-table tbody td {
+      padding: 10px; }
+      .install-update .install-update-status-table tbody td:first-child {
+        text-align: left; }

--- a/frontend/views/install_update.html
+++ b/frontend/views/install_update.html
@@ -2,5 +2,26 @@
   <div class="install-update-box">
     <img src="images/spinner.gif">
     <p>Installing update, this can take a while …</p>
+    <div class="install-update-status" ng-show="statusAvailable">
+      <button class="btn" ng-click="toggleDetailedUpdateStatus()">{{showDetailedUpdateStatus ? 'hide' : 'show'}} details</button>
+      <table class="install-update-status-table" ng-show="showDetailedUpdateStatus">
+        <thead>
+          <tr>
+            <td>Image</td>
+            <td>Local</td>
+            <td>Remote</td>
+            <td>up to date?</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="(imageName, image) in status">
+            <td>{{imageName}}</td>
+            <td>{{image.local}}</td>
+            <td>{{image.remote}}</td>
+            <td>{{image.upToDate ? 'yes' : 'no'}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This adds more detailed informations on the update status. This should help the user to get an idea of what's going on. Your thoughts?

![detailed-status](https://cloud.githubusercontent.com/assets/5122/9956893/65cc3e1c-5dfc-11e5-8381-70221c09cd76.png)
