### PR TITLE
fix an issue with hardlinks on AUFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,11 @@ RUN curl -sL https://deb.nodesource.com/setup | sudo bash - && \
     rm -rf /var/lib/apt/lists/*
 
 COPY management-proxy/session-manager /app
-WORKDIR /app
-RUN npm install
+RUN cd /app && npm install
 
-WORKDIR /
-ADD frontend /build
-WORKDIR /build
-RUN npm install -g bower
-RUN bower --allow-root install && mv * /app/public/
+COPY frontend /app/public
+RUN cd /app/public && npm install -g bower
+RUN cd /app/public && bower --allow-root install
 
 WORKDIR /app
 EXPOSE 3000


### PR DESCRIPTION
```
mv: will not create hard link '/app/public/scripts/models' to directory '/app/public/images/technology-logos'
mv: will not create hard link '/app/public/scripts/lib' to directory '/app/public/images/icons'                                                                                                                                                      
mv: cannot create hard link '/app/public/views/styleguide.html' to '/app/public/styles/application': Operation not permitted                                                                                                                         
mv: cannot create hard link '/app/public/views/welcome-1.html' to '/app/public/styles/application/base': Operation not permitted                                                                                                                     
mv: cannot create hard link '/app/public/views/welcome-4.html' to '/app/public/styles/application/pages': Operation not permitted                                                                                                                    
mv: cannot create hard link '/app/public/views/create-app-3.html' to '/app/public/styles/application/modules': Operation not permitted                                                                                                               
mv: cannot create hard link '/app/public/views/layout.html' to '/app/public/styles/application/globals': Operation not permitted                                                                                                                     
The command '/bin/sh -c bower --allow-root install && mv * /app/public/' returned a non-zero code: 1
```

/cc @tiff 
