### PR TITLE
Do not crash server when password is an array

### DIFF
--- a/management-proxy/session-manager/routes/sessions.js
+++ b/management-proxy/session-manager/routes/sessions.js
@@ -35,7 +35,7 @@ module.exports = function(router) {
   });
 
   var check_password = function(secret, callback) {
-    if (!secret) {
+    if (!secret || typeof(secret) !== "string") {
       console.log("Password empty.");
       callback(false);
       return;


### PR DESCRIPTION
Daniel managed to crash our platform by posting the password param as an array. 
